### PR TITLE
Appeng 787 - Portability between OSD clusters and normal OCP clusters

### DIFF
--- a/install/isv-monitoring-incluster/install/config/mso/bases/clusterrole.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/bases/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: <monitored_namespace>-prometheus-cr
+  name: mso-prometheus-cr
 rules:
 - apiGroups:
   - ""

--- a/install/isv-monitoring-incluster/install/config/mso/bases/clusterrole.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/bases/clusterrole.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: <monitored_namespace>-prometheus-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+# - apiGroups:
+#   - authentication.k8s.io
+#   resources:
+#   - tokenreviews
+#   verbs:
+#   - create
+# - apiGroups:
+#   - authorization.k8s.io
+#   resources:
+#   - subjectaccessreviews
+#   verbs:
+#   - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  verbs:
+  - get
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/install/isv-monitoring-incluster/install/config/mso/bases/kustomization.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/bases/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- clusterrole.yaml
 - rolebinding.yaml
 - monitoringstack.generated.yaml
 - servicemonitor.yaml

--- a/install/isv-monitoring-incluster/install/config/mso/bases/rolebinding.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/bases/rolebinding.yaml
@@ -9,4 +9,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: <monitored_namespace>-prometheus-cr
+  name: mso-prometheus-cr

--- a/install/isv-monitoring-incluster/install/config/mso/bases/rolebinding.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/bases/rolebinding.yaml
@@ -9,4 +9,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-user-workload
+  name: <monitored_namespace>-prometheus-cr


### PR DESCRIPTION
This PR Addresses portability between OSD clusters and normal OCP clusters.

_There is a new clusterrole that is created from the user-workload-monitoring clusterrole only with less permissions._

_The Kustomize.yaml has been updated to process the new clusterrole._

_The ClusterRoleBinding has been updated to bind the new ClusterRole to the prometheus service account._

This has been tested on OpenShift Dedicated and OCP 4.10 running on AWS.

**The reason this clusterrole has a new name is because it will get deleted on vanilla OCP if it does not.**