### PR TITLE
[FIX] update subscription channel

### DIFF
--- a/install/isv-monitoring-incluster/install/config/operator/bases/subscription.yaml
+++ b/install/isv-monitoring-incluster/install/config/operator/bases/subscription.yaml
@@ -6,9 +6,8 @@ metadata:
   name: observability-operator
   namespace: openshift-operators
 spec:
-  channel: stable
+  channel: development
   installPlanApproval: Automatic
   name: observability-operator
   source: observability-operator
   sourceNamespace: openshift-marketplace
-  startingCSV: observability-operator.v0.0.11

--- a/install/isv-monitoring-incluster/install/config/operator/bases/subscription.yaml
+++ b/install/isv-monitoring-incluster/install/config/operator/bases/subscription.yaml
@@ -11,3 +11,4 @@ spec:
   name: observability-operator
   source: observability-operator
   sourceNamespace: openshift-marketplace
+#  startingCSV: observability-operator.v0.0.12-220630095130  


### PR DESCRIPTION
Closes #12 

The upstream has updated their subscription to the `development` channel. 

I have left the `startingCSV` property commented in the subscription. Would we prefer to have this uncommented? 