### PR TITLE
[UPDATE] writeRelabelConfigs for new metrics

### DIFF
--- a/install/isv-monitoring-incluster/install/config/mso/dev/patch-remotewrite.yaml
+++ b/install/isv-monitoring-incluster/install/config/mso/dev/patch-remotewrite.yaml
@@ -17,7 +17,7 @@ spec:
         writeRelabelConfigs:
           - action: keep
             regex: >-
-              (csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|subscription_sync_total|trino_.*$|jvm_heap_memory_used$|node_.*$|namespace_.*$)
+              (csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|subscription_sync_total|trino_.*$|jvm_heap_memory_used$|node_.*$|namespace_.*$|kube_.*$|cluster.*$|container_.*$)
             sourceLabels:
               - __name__
     replicas: 1


### PR DESCRIPTION
Accommodate newly added metrics on the MSO. This PR add more metrics to the `writeRelabelConfigs` that will ultimate be sent to observatorium